### PR TITLE
FEAT: Select Notes from Specific Years, Months or Days by Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,116 @@
+# Monolog: A Note-Taking CLI Tool
+
+Monolog is a simple command-line application for managing notes. It allows you to add notes, view today's notes, and retrieve the most recent notes.
+
+## Features
+
+- Add Notes: Add new notes quickly from the command line.
+- Today's Notes: Display notes created today.
+- Recent Notes: View a specific number of the most recent notes.
+
+## Prerequisites
+
+Ensure you have the following tools installed:
+
+### 1. Rust and Cargo
+
+Run `rustc --version` and `cargo --version` to confirm installation.
+
+### 2. SQLite: SQLite is required for the database.
+
+## Installation
+
+Follow these steps to install and build monolog:
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/alexpetrean80/monolog.git
+cd monolog
+```
+
+### 2. Install Dependencies
+
+`monolog` uses the following dependencies:
+
+`tokio`: For async runtime.
+`sqlx`: For database interactions.
+`chrono`: To handle date and time.
+`clap`: To parse command-line arguments.
+
+These dependencies are specified in Cargo.toml. To fetch and install them, run:
+
+```bash
+cargo fetch
+```
+
+### 3. Build the Application
+
+Compile the project using Cargo:
+
+```bash
+cargo build --release
+```
+
+The binary will be available in the target/release directory.
+
+## Usage
+
+The `monolog` application provides the following subcommands:
+
+### 1. Add a Note
+
+To add a new note:
+
+```bash
+monolog add <your_note>
+```
+
+Example:
+
+```bash
+monolog add "This is my first note."
+```
+
+### 2. View Today's Notes
+
+To display all notes added today:
+
+```bash
+monolog today
+```
+
+Example output:
+
+```shell
+# 2024-06-17
+
+## 14:32
+> This is my first note.
+
+## 15:45
+> Follow up on project status.
+```
+
+### 3. View Recent Notes
+
+To display the n most recent notes:
+
+```bash
+monolog last <number_of_notes>
+```
+
+Example:
+
+```bash
+monolog last 5
+```
+
+## Database
+
+- The application uses a SQLite database file named monolog.db, which is created automatically in the working directory on the first run.
+
+- Notes are stored in the table notes with the following fields:
+  `id`: Auto-incrementing primary key.
+  `text`: The note content.
+  `date`: Timestamp of when the note was added.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ Follow these steps to install and build monolog:
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/alexpetrean80/monolog.git
-cd monolog
+cargo install --git https://github.com/alexpetrean80/monolog.git
 ```
 
 ### 2. Install Dependencies
@@ -105,12 +104,3 @@ Example:
 ```bash
 monolog last 5
 ```
-
-## Database
-
-- The application uses a SQLite database file named monolog.db, which is created automatically in the working directory on the first run.
-
-- Notes are stored in the table notes with the following fields:
-  `id`: Auto-incrementing primary key.
-  `text`: The note content.
-  `date`: Timestamp of when the note was added.

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,14 @@ enum Commands {
         no_notes: u8,
     },
     Today {},
+    From {
+        #[arg(short, long)]
+        year: Option<u16>,
+        #[arg(short, long)]
+        month: Option<u8>,
+        #[arg(short, long)]
+        day: Option<u8>,
+    },
 }
 
 impl Commands {
@@ -31,6 +39,11 @@ impl Commands {
             }
             Commands::Today {} => {
                 let notes = db.get_todays_notes().await?;
+                notes.print();
+                Ok(())
+            }
+            Commands::From { year, month, day  } => {
+                let notes = db.get_notes_from(year, month, day).await?;
                 notes.print();
                 Ok(())
             }


### PR DESCRIPTION
## Usage

```sh
monolog from -y [year] -m [month] -d [day]
```

The arguments can be provided separately as well to select only a specific year, month or day.

Example:
![image](https://github.com/user-attachments/assets/dfa2ab4e-ffc8-46b6-a546-dd8780192ac1)

If you're providing a day (say 17) without a month, it's going to take the current month. The same goes with the rest of the parameters. If you're only providing the month, it's going to consider the month of the current year.

Couldn't figure out a cleaner way to implement the `get_notes_from` function as I'm a mediocre developer. Never touched Rust either. Feedback is *VERY* welcome.

## Fixes

Fixed a small formatting issue in the `print` function where for the `00:XX` time, we'd get a weird `0:X` formatting, as seen in the screenshot below.

![image](https://github.com/user-attachments/assets/997b7583-c6de-480f-8a04-86bf58c67aa1)
